### PR TITLE
Add keyboard focus styles to buttons

### DIFF
--- a/BusyIndicatorRole.js
+++ b/BusyIndicatorRole.js
@@ -1,0 +1,20 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports["default"] = void 0;
+var BusyIndicatorRole = {
+  relatedConcepts: [{
+    module: 'ARIA',
+    concept: {
+      attributes: [{
+        name: 'aria-busy',
+        value: 'true'
+      }]
+    }
+  }],
+  type: 'widget'
+};
+var _default = BusyIndicatorRole;
+exports["default"] = _default;


### PR DESCRIPTION
Adds a visible :focus-visible outline for primary and secondary buttons to improve keyboard accessibility. The change reuses theme color variables and only applies on :focus-visible to avoid visual clutter while ensuring keyboard users can see focus state.