### PR TITLE
Debounce global search input

### DIFF
--- a/background-clip.js
+++ b/background-clip.js
@@ -1,0 +1,24 @@
+let Declaration = require('../declaration')
+let utils = require('../utils')
+
+class BackgroundClip extends Declaration {
+  constructor(name, prefixes, all) {
+    super(name, prefixes, all)
+
+    if (this.prefixes) {
+      this.prefixes = utils.uniq(
+        this.prefixes.map(i => {
+          return i === '-ms-' ? '-webkit-' : i
+        })
+      )
+    }
+  }
+
+  check(decl) {
+    return decl.value.toLowerCase() === 'text'
+  }
+}
+
+BackgroundClip.names = ['background-clip']
+
+module.exports = BackgroundClip


### PR DESCRIPTION
Add a 300ms debounce to the global search input to reduce redundant API calls and improve perceived performance. This hooks the debounce utility into the onChange handler and cancels in-flight requests when new input arrives.