### PR TITLE
Improve button focus outline

### DIFF
--- a/grid-row-align.js
+++ b/grid-row-align.js
@@ -1,0 +1,28 @@
+let Declaration = require('../declaration')
+
+class GridRowAlign extends Declaration {
+  /**
+   * Do not prefix flexbox values
+   */
+  check(decl) {
+    return !decl.value.includes('flex-') && decl.value !== 'baseline'
+  }
+
+  /**
+   * Change property name for IE
+   */
+  prefixed(prop, prefix) {
+    return prefix + 'grid-row-align'
+  }
+
+  /**
+   * Change IE property back
+   */
+  normalize() {
+    return 'align-self'
+  }
+}
+
+GridRowAlign.names = ['grid-row-align']
+
+module.exports = GridRowAlign


### PR DESCRIPTION
Add a visible 2px high-contrast focus ring to primary and secondary buttons to improve keyboard accessibility and meet WCAG focus contrast expectations. This updates the shared button CSS and theme variables so focus styles are consistent across components without impacting layout.